### PR TITLE
Controller review Patch method has been created

### DIFF
--- a/BioscoopServer/Controllers/ReviewController.cs
+++ b/BioscoopServer/Controllers/ReviewController.cs
@@ -39,7 +39,7 @@ namespace Controllers
             if (user == null)
                 return BadRequest($"There is no user with this id: {userId}");
 
-            var review = new Review
+            Review review = new Review
             {
                 Id = Guid.NewGuid(),
                 UserId = userId,
@@ -50,7 +50,7 @@ namespace Controllers
 
             var addedReview = await _DBReviewService.AddAsync(review);
 
-            var responseDTO = new ReviewDTO
+            ReviewDTO responseDTO = new ReviewDTO
             {
                 Id = addedReview.Id.ToString(),
                 UserId = addedReview.UserId.ToString(),
@@ -122,5 +122,38 @@ namespace Controllers
             return Ok(reviewDTO);
         }
 
+        [HttpPatch("{id}")]
+        public async Task<IActionResult> UpdateReview(Guid id, [FromBody] ReviewUpdateDTO UpdatedReview)
+        {
+            Review? existingReview = await _context.Reviews.FindAsync(id);
+
+            if (existingReview == null)
+                return NotFound($"No review found with id: {id}");
+
+            if (UpdatedReview == null)
+                return BadRequest("Nothing was filled in.");
+
+            if (UpdatedReview.Rating < 1 || UpdatedReview.Rating > 5)
+                return BadRequest("Rating must be between 1 and 5.");
+
+            if (UpdatedReview.Rating.HasValue)
+                existingReview.Rating = UpdatedReview.Rating.Value;
+
+            if (!string.IsNullOrWhiteSpace(UpdatedReview.Description))
+                existingReview.Description = UpdatedReview.Description;
+
+            Review updatedReview = await _DBReviewService.UpdateAsync(existingReview);
+
+            ReviewDTO responseDTO = new ReviewDTO
+            {
+                Id = updatedReview.Id.ToString(),
+                UserId = updatedReview.UserId.ToString(),
+                FilmId = updatedReview.FilmId.ToString(),
+                Rating = updatedReview.Rating,
+                Description = updatedReview.Description
+            };
+
+            return Ok(responseDTO);
+        }
     }
 }

--- a/BioscoopServer/Models/ModelsDTOs/ReviewDTO.cs
+++ b/BioscoopServer/Models/ModelsDTOs/ReviewDTO.cs
@@ -12,4 +12,11 @@ namespace BioscoopServer.Models.ModelsDTOs
         public string? Description {get; set;}
 
     }
+
+    public class ReviewUpdateDTO
+    {
+        public int? Rating { get; set; }
+
+        public string? Description { get; set; }
+    }
 }

--- a/BioscoopServer/Rest/.rest
+++ b/BioscoopServer/Rest/.rest
@@ -4,7 +4,7 @@ Content-Type: application/json
 
 {
   "id": "",
-  "userId": "14130273-39A2-4451-8AD7-0A7317891827",
+  "userId": "3B84AD03-DABC-45C6-AB69-FB53C0938CA0",
   "filmId": "5243C985-4825-4E06-BA3C-779171E93C96",
   "rating": 5,
   "description": "Love it !"
@@ -15,7 +15,7 @@ Content-Type: application/json
 DELETE http://localhost:5275/api/Review/27F5493F-3B7A-4B4A-A431-15A58C3643EA
 Content-Type: application/json
 
-### Get Reviews id
+### Get Reviews by id
 GET http://localhost:5275/api/Review/D1E4C5E8-E0B3-45B5-BE0C-E7DDF1A44C88
 Content-Type: application/json
 
@@ -23,4 +23,12 @@ Content-Type: application/json
 GET http://localhost:5275/api/Review/GetAll
 Content-Type: application/json
 
-###
+### Review update
+
+PATCH http://localhost:5275/api/Review/9D047ECC-8CCD-4C04-919B-BB75689DE32B
+Content-Type: application/json
+
+{
+  "rating": 5,
+  "description": "Update test 2"
+}


### PR DESCRIPTION
This pull request introduces an update feature for reviews, allowing users to modify their review's rating and description. It also adds a new DTO for partial updates and updates the REST API documentation to reflect the new endpoint. Minor improvements to code style are also included.

**Review Update Feature:**

* Added a new `UpdateReview` endpoint (`PATCH /api/Review/{id}`) to allow updating the rating and description of an existing review. The endpoint validates input, updates only provided fields, and returns the updated review as a DTO.
* Introduced the `ReviewUpdateDTO` class to support partial updates of review fields (`rating` and `description`).

**REST API Documentation:**

* Updated the REST API documentation in `BioscoopServer/Rest/.rest` to include an example request for the new review update endpoint and adjusted sample user IDs for clarity. [[1]](diffhunk://#diff-ce66f9d4c18b1cb74cace7e99fb1d45bd5038900fe827f8a8454ea7716540896L7-R7) [[2]](diffhunk://#diff-ce66f9d4c18b1cb74cace7e99fb1d45bd5038900fe827f8a8454ea7716540896L18-R34)

**Code Style Improvements:**

* Changed variable declarations from `var` to explicit types (`Review` and `ReviewDTO`) in the `AddReview` method for better readability. [[1]](diffhunk://#diff-9785c4ee2a7a2da9c9cc4f9e0be0140a42d314dc2463bbeec0a32c4e340c8330L42-R42) [[2]](diffhunk://#diff-9785c4ee2a7a2da9c9cc4f9e0be0140a42d314dc2463bbeec0a32c4e340c8330L53-R53)…updated and I also added 1 test for it in the .rest file and I also added a reviewupdatedto in order to only use 2 fields when updating, so that the other parts of the review stays untouched